### PR TITLE
[Fix] Correct Table of Contents links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cp .env.example .env
 # Run the advisor
 run-advisor
 ```  
+
 <a id="installation"></a>
 ## 🚀 Installation
 
@@ -96,9 +97,7 @@ cp .env.example .env
 
 **Note:** Portfolios limited to 4 ETFs and 2 years of data (free Polygon.io constraints).
 
-
 <a id="usage"></a>
-
 ## 💼 Usage
 
 ### Command Line Interface
@@ -114,9 +113,7 @@ run-advisor --show-reasoning
 
 ![Analysis Response](assets/analysis-response.png)
 
-
 <a id="testing"></a>
-
 ## 🧪 Testing
 
 Comprehensive test suite for code quality and regression prevention.
@@ -143,7 +140,6 @@ pip install -e ".[test]"
 ```
 
 <a id="contributing"></a>
-
 ## 🤝 Contributing
 
 Contributions welcome! Please:
@@ -156,7 +152,6 @@ Contributions welcome! Please:
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for detailed guidelines.
 
 <a id="license"></a>
-
 ## 📄 License
 
 Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information.


### PR DESCRIPTION
## Description
Fixed broken Table of Contents links in the README file.

## Type of Change
- [x] Bug fix
- [ ] Documentation update

## Related Issues
Closes #29 

## Testing
- Checked all TOC links locally in Markdown preview
- Verified styling remains unchanged

✅ All links now work correctly

## Proof of Fix
Here’s a video showing the issue after the fix:

https://github.com/user-attachments/assets/711f145d-f43c-425f-b664-b0ee4cadddef


